### PR TITLE
remove 'RUST_SRC_PATH' env

### DIFF
--- a/editor/.config/nvim/init.vim
+++ b/editor/.config/nvim/init.vim
@@ -135,7 +135,6 @@ let g:rustfmt_fail_silently = 0
 let g:rust_clip_command = 'xclip -selection clipboard'
 "let g:racer_cmd = "/usr/bin/racer"
 "let g:racer_experimental_completer = 1
-let $RUST_SRC_PATH = systemlist("rustc --print sysroot")[0] . "/lib/rustlib/src/rust/src"
 
 " Completion
 " Better display for messages


### PR DESCRIPTION
'RUST_SRC_PATH' env doesn't correct since rust 1.47, and it will give rust-analyzer a misleading to rust-analyzer. For a typical error: 
<img width="1277" alt="截屏2020-10-30 下午2 12 00" src="https://user-images.githubusercontent.com/65523321/97668049-1f864880-1abc-11eb-84f5-a806f8945463.png">

After remove this env, RA works well. If you don't use rust-analyzer both in rust 1.47 and previous version.