### PR TITLE
Firefox: hiding toolbox in fullscreen mode

### DIFF
--- a/gui/.mozilla/firefox/chrome/userChrome.css
+++ b/gui/.mozilla/firefox/chrome/userChrome.css
@@ -32,4 +32,5 @@
 	.tabbrowser-tab { font-size: 80%; }
 	.tab-content { padding: 0 5px; }
 	.tab-close-button .toolbarbutton-icon { width: 12px !important; height: 12px !important; }
+	toolbox[inFullscreen=true] { display: none; }
 }


### PR DESCRIPTION
Without this the available screen height gets miscalculated as Firefox thinks that the whole screen height is available showing page content behind the toolbar which is annoying when there is something interesting at the bottom of the page.

There surely must be a better way to fix that so the toolbar comes out when you move the cursor to the bottom of the screen but this works well enough.

Environment: This works for me on stock Ubuntu 20.04 LTS (Xorg + Gnome 3.36.8). Haven't tried it on other setups.