### PR TITLE
Remove obsolete workaround for Fish polluting clipboard

### DIFF
--- a/server/.config/fish/config.fish
+++ b/server/.config/fish/config.fish
@@ -57,10 +57,6 @@ if test -e ~/.cargo-target
 end
 set PATH $PATH ~/.cargo/bin
 
-# Fish should not add things to clipboard when killing
-# See https://github.com/fish-shell/fish-shell/issues/772
-set FISH_CLIPBOARD_CMD "cat"
-
 function fish_prompt
 	set_color brblack
 	echo -n "["(date "+%H:%M")"] "


### PR DESCRIPTION
See: https://github.com/fish-shell/fish-shell/commit/2f51088bfb950ab0edcc53668c74e7fb6c58613f.
This env variable is no longer used and this workaround should not be needed anymore.