### PR TITLE
Replace  vim-highlightedyank with lua function

### DIFF
--- a/editor/.config/nvim/init.vim
+++ b/editor/.config/nvim/init.vim
@@ -19,7 +19,6 @@ Plug 'justinmk/vim-sneak'
 
 " GUI enhancements
 Plug 'itchyny/lightline.vim'
-Plug 'machakann/vim-highlightedyank'
 Plug 'andymass/vim-matchup'
 
 " Fuzzy finder
@@ -365,6 +364,7 @@ set colorcolumn=80 " and give me a colored column
 set showcmd " Show (partial) command in status line.
 set mouse=a " Enable mouse usage (all modes) in terminals
 set shortmess+=c " don't give |ins-completion-menu| messages.
+au TextYankPost * silent! lua vim.highlight.on_yank() " Highlight yank
 
 " Show those damn hidden characters
 " Verbose: set listchars=nbsp:¬,eol:¶,extends:»,precedes:«,trail:•


### PR DESCRIPTION
Apparently, for Neovim you don't need the plugin. 

But if you've been keeping it by reasoning with Vim comparability ... then never mind 😅 ... in the other case, here's the links:
- https://github.com/machakann/vim-highlightedyank#if-you-are-using-neovim
- https://neovim.io/doc/user/lua.html#lua-highlight