### PR TITLE
use +yy for copying and fix comment

### DIFF
--- a/editor/.config/nvim/init.vim
+++ b/editor/.config/nvim/init.vim
@@ -410,11 +410,11 @@ nnoremap <C-f> :sus<cr>
 map H ^
 map L $
 
-" Neat X clipboard integration
-" ,p will paste clipboard into buffer
-" ,c will copy entire buffer into clipboard
+" System clipboard integration
+" <leader>p to paste clipboard into buffer
+" <leader>c to copy selection or line
 noremap <leader>p :read !xsel --clipboard --output<cr>
-noremap <leader>c :w !xsel -ib<cr><cr>
+noremap <leader>c "+yy
 
 " <leader>s for Rg search
 noremap <leader>s :Rg


### PR DESCRIPTION
this part of config seems very outdated/wrong, at least it doesn't work as described for me.

the `"+yy` behavior is lightly different from xsel: it still copies entire line to system clipboard but if there is selection, it copies that.

there is `"+p` that pastes on cursor instead of newline and overwrites selection but it's behaviour is very different from current xsel pasting so i did not include it here