### PR TITLE
fix: searchmode-switcher selector for certain updated firefox versions

### DIFF
--- a/gui/.mozilla/firefox/chrome/userChrome.css
+++ b/gui/.mozilla/firefox/chrome/userChrome.css
@@ -7,7 +7,7 @@
 	 */
 	#main-window body { flex-direction: column-reverse !important; }
 	#navigator-toolbox { flex-direction: column-reverse !important; }
-	#urlbar-searchmode-switcher { position: static !important; }
+	#urlbar-searchmode-switcher, .searchmode-switcher { position: static !important; }
 	#urlbar {
 		top: unset !important;
 		bottom: calc(var(--urlbar-container-height) + 2 * var(--urlbar-padding-block)) !important;


### PR DESCRIPTION
Apologies for taking your time;

On (at least) Firefox version `151.0.4` with build `20260609033100`, the browser DOM has changed such that the searchmode switcher now uses a class instead of ID. Adding the class-based selector makes the `position: static` style take effect again.